### PR TITLE
Add source app display toggle

### DIFF
--- a/app/src/main/java/com/gululu/aamediamate/LyricDisplayManager.kt
+++ b/app/src/main/java/com/gululu/aamediamate/LyricDisplayManager.kt
@@ -110,8 +110,9 @@ class LyricDisplayManager(private val context: Context) {
         val metadataBuilder = MediaMetadataCompat.Builder()
             .putLong(MediaMetadataCompat.METADATA_KEY_DURATION, originalInfo.duration)
 
-        // Always set the album to "From [App Name]"
-        metadataBuilder.putString(MediaMetadataCompat.METADATA_KEY_ALBUM, "From ${originalInfo.appName}")
+        if (SettingsManager.getShowSourceApp(context)) {
+            metadataBuilder.putString(MediaMetadataCompat.METADATA_KEY_ALBUM, "From ${originalInfo.appName}")
+        }
 
         val showAlbumName = SettingsManager.getShowAlbumName(context)
 

--- a/app/src/main/java/com/gululu/aamediamate/MediaBridgeSessionManager.kt
+++ b/app/src/main/java/com/gululu/aamediamate/MediaBridgeSessionManager.kt
@@ -65,6 +65,17 @@ object MediaBridgeSessionManager {
 
     fun getCurrentMediaPackage(): String? = currentMediaInfo?.appPackageName
 
+    /** Rebuilds the active bridged session after a display preference changes. */
+    fun refreshCurrentSession(forceLyricsResync: Boolean = false) {
+        val ctx = context ?: return
+        val refreshedInfo = MediaInformationRetriever.refreshCurrentMediaInfo(
+            ctx,
+            currentMediaInfo?.appPackageName
+        ) ?: currentMediaInfo ?: return
+
+        updateFromMediaInfo(refreshedInfo, forceLyricsResync)
+    }
+
     fun setMediaInfoListener(listener: (MediaInfo?) -> Unit) {
         mediaInfoListener = listener
     }

--- a/app/src/main/java/com/gululu/aamediamate/MediaStateUpdater.kt
+++ b/app/src/main/java/com/gululu/aamediamate/MediaStateUpdater.kt
@@ -36,7 +36,9 @@ class MediaStateUpdater(private val context: Context) {
             metadataBuilder.putString(MediaMetadataCompat.METADATA_KEY_ARTIST, artistText)
         }
 
-        metadataBuilder.putString(MediaMetadataCompat.METADATA_KEY_ALBUM, "From ${info.appName}")
+        if (SettingsManager.getShowSourceApp(context)) {
+            metadataBuilder.putString(MediaMetadataCompat.METADATA_KEY_ALBUM, "From ${info.appName}")
+        }
 
         info.albumArt?.let {
             metadataBuilder.putBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART, it)

--- a/app/src/main/java/com/gululu/aamediamate/SettingsManager.kt
+++ b/app/src/main/java/com/gululu/aamediamate/SettingsManager.kt
@@ -26,6 +26,7 @@ object SettingsManager {
     private const val KEY_LYRICS_CLEANUP_RULES = "lyrics_cleanup_rules"
     private const val KEY_COMBINE_APP_ICON_AND_ALBUM_ART = "combine_app_icon_and_album_art"
     private const val KEY_SHOW_ALBUM_NAME = "show_album_name"
+    private const val KEY_SHOW_SOURCE_APP = "show_source_app"
     private const val KEY_LYRICS_TIMING_OFFSET = "lyrics_timing_offset"
 
     private fun getPrefs(context: Context) = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -44,6 +45,7 @@ object SettingsManager {
             put(KEY_LYRICS_CLEANUP_RULES, lyricsCleanupRulesToJson(getLyricsCleanupRules(context)))
             put(KEY_COMBINE_APP_ICON_AND_ALBUM_ART, getCombineAppIconAndAlbumArt(context))
             put(KEY_SHOW_ALBUM_NAME, getShowAlbumName(context))
+            put(KEY_SHOW_SOURCE_APP, getShowSourceApp(context))
             put(KEY_LYRICS_TIMING_OFFSET, getLyricsTimingOffset(context))
 
             if (includeSecrets) {
@@ -67,6 +69,7 @@ object SettingsManager {
                 putBoolean(KEY_COMBINE_APP_ICON_AND_ALBUM_ART, it)
             }
             settings.optBooleanOrNull(KEY_SHOW_ALBUM_NAME)?.let { putBoolean(KEY_SHOW_ALBUM_NAME, it) }
+            settings.optBooleanOrNull(KEY_SHOW_SOURCE_APP)?.let { putBoolean(KEY_SHOW_SOURCE_APP, it) }
             settings.optIntOrNull(KEY_LYRICS_TIMING_OFFSET)?.let { putInt(KEY_LYRICS_TIMING_OFFSET, it) }
             settings.optStringOrNull(KEY_API_KEY)?.let { putString(KEY_API_KEY, it) }
             settings.optStringOrNull(KEY_LRC_API_AUTH_TOKEN)?.let { putString(KEY_LRC_API_AUTH_TOKEN, it) }
@@ -85,6 +88,13 @@ object SettingsManager {
 
     fun setShowAlbumName(context: Context, enabled: Boolean) {
         getPrefs(context).edit() { putBoolean(KEY_SHOW_ALBUM_NAME, enabled) }
+    }
+
+    fun getShowSourceApp(context: Context): Boolean =
+        getPrefs(context).getBoolean(KEY_SHOW_SOURCE_APP, true)
+
+    fun setShowSourceApp(context: Context, enabled: Boolean) {
+        getPrefs(context).edit() { putBoolean(KEY_SHOW_SOURCE_APP, enabled) }
     }
 
     fun getLyricsTimingOffset(context: Context): Int =

--- a/app/src/main/java/com/gululu/aamediamate/ui/DisplaySettingsScreen.kt
+++ b/app/src/main/java/com/gululu/aamediamate/ui/DisplaySettingsScreen.kt
@@ -24,6 +24,7 @@ fun DisplaySettingsScreen(onBack: () -> Unit) {
     val context = LocalContext.current
     var combineAppIconAndAlbumArt by remember { mutableStateOf(SettingsManager.getCombineAppIconAndAlbumArt(context)) }
     var showAlbumName by remember { mutableStateOf(SettingsManager.getShowAlbumName(context)) }
+    var showSourceApp by remember { mutableStateOf(SettingsManager.getShowSourceApp(context)) }
 
     Scaffold(
         topBar = {
@@ -97,6 +98,34 @@ fun DisplaySettingsScreen(onBack: () -> Unit) {
                     onCheckedChange = {
                         showAlbumName = it
                         SettingsManager.setShowAlbumName(context, it)
+                    }
+                )
+            }
+
+            HorizontalDivider()
+
+            // Show Source App Toggle
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(id = R.string.show_source_app_title),
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                    Text(
+                        text = stringResource(id = R.string.show_source_app_subtitle),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Switch(
+                    checked = showSourceApp,
+                    onCheckedChange = {
+                        showSourceApp = it
+                        SettingsManager.setShowSourceApp(context, it)
                     }
                 )
             }

--- a/app/src/main/java/com/gululu/aamediamate/ui/DisplaySettingsScreen.kt
+++ b/app/src/main/java/com/gululu/aamediamate/ui/DisplaySettingsScreen.kt
@@ -2,6 +2,8 @@ package com.gululu.aamediamate.ui
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
@@ -11,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.gululu.aamediamate.MediaBridgeSessionManager
 import com.gululu.aamediamate.R
 import com.gululu.aamediamate.SettingsManager
 
@@ -45,7 +48,8 @@ fun DisplaySettingsScreen(onBack: () -> Unit) {
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
-                .padding(16.dp),
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             // Combine App Icon & Album Art Toggle
@@ -70,6 +74,7 @@ fun DisplaySettingsScreen(onBack: () -> Unit) {
                     onCheckedChange = {
                         combineAppIconAndAlbumArt = it
                         SettingsManager.setCombineAppIconAndAlbumArt(context, it)
+                        MediaBridgeSessionManager.refreshCurrentSession(forceLyricsResync = true)
                     }
                 )
             }
@@ -98,6 +103,7 @@ fun DisplaySettingsScreen(onBack: () -> Unit) {
                     onCheckedChange = {
                         showAlbumName = it
                         SettingsManager.setShowAlbumName(context, it)
+                        MediaBridgeSessionManager.refreshCurrentSession(forceLyricsResync = true)
                     }
                 )
             }
@@ -126,6 +132,7 @@ fun DisplaySettingsScreen(onBack: () -> Unit) {
                     onCheckedChange = {
                         showSourceApp = it
                         SettingsManager.setShowSourceApp(context, it)
+                        MediaBridgeSessionManager.refreshCurrentSession(forceLyricsResync = true)
                     }
                 )
             }

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -67,6 +67,8 @@
     <string name="combine_app_icon_and_album_art_subtitle">在專輯封面上顯示應用程式圖示</string>
     <string name="show_album_name_title">顯示專輯名稱</string>
     <string name="show_album_name_subtitle">在演出者行中顯示專輯名稱</string>
+    <string name="show_source_app_title">顯示來源應用程式</string>
+    <string name="show_source_app_subtitle">在車載螢幕上顯示「From [應用程式]」</string>
 
     <!-- Main Screen -->
     <string name="app_title">AA Media Mate</string>

--- a/app/src/main/res/values-zh-rMO/strings.xml
+++ b/app/src/main/res/values-zh-rMO/strings.xml
@@ -67,6 +67,8 @@
     <string name="combine_app_icon_and_album_art_subtitle">在專輯封面上顯示應用程式圖示</string>
     <string name="show_album_name_title">顯示專輯名稱</string>
     <string name="show_album_name_subtitle">在演出者行中顯示專輯名稱</string>
+    <string name="show_source_app_title">顯示來源應用程式</string>
+    <string name="show_source_app_subtitle">在車載螢幕上顯示「From [應用程式]」</string>
 
     <!-- Main Screen -->
     <string name="app_title">AA Media Mate</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -67,6 +67,8 @@
     <string name="combine_app_icon_and_album_art_subtitle">在專輯封面上顯示應用程式圖示</string>
     <string name="show_album_name_title">顯示專輯名稱</string>
     <string name="show_album_name_subtitle">在演出者行中顯示專輯名稱</string>
+    <string name="show_source_app_title">顯示來源應用程式</string>
+    <string name="show_source_app_subtitle">在車載螢幕上顯示「From [應用程式]」</string>
 
     <!-- Main Screen -->
     <string name="app_title">AA Media Mate</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -66,6 +66,8 @@
     <string name="combine_app_icon_and_album_art_subtitle">在专辑封面上显示应用图标</string>
     <string name="show_album_name_title">显示专辑名称</string>
     <string name="show_album_name_subtitle">在艺术家行中显示专辑名称</string>
+    <string name="show_source_app_title">显示来源应用</string>
+    <string name="show_source_app_subtitle">在车载屏幕上显示“From [应用]”</string>
 
     <!-- Main Screen -->
     <string name="app_title">AA Media Mate</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,8 @@
     <string name="combine_app_icon_and_album_art_subtitle">Show app icon on album art</string>
     <string name="show_album_name_title">Show Album Name</string>
     <string name="show_album_name_subtitle">Show album name in artist line</string>
+    <string name="show_source_app_title">Show Source App</string>
+    <string name="show_source_app_subtitle">Show “From [app]” on the car display</string>
 
     <!-- Main Screen -->
     <string name="app_title">AA Media Mate</string>

--- a/app/src/test/java/com/gululu/aamediamate/LyricDisplayManagerTest.kt
+++ b/app/src/test/java/com/gululu/aamediamate/LyricDisplayManagerTest.kt
@@ -10,6 +10,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -21,13 +22,15 @@ class LyricDisplayManagerTest {
 
     private val context = mockk<Context>(relaxed = true)
     private val mediaSession = mockk<MediaSessionCompat>(relaxed = true)
+    private lateinit var prefs: SharedPreferences
     private lateinit var manager: LyricDisplayManager
 
     @Before
     fun setUp() {
-        val prefs = mockk<SharedPreferences>(relaxed = true)
+        prefs = mockk(relaxed = true)
         every { context.getSharedPreferences(any(), any()) } returns prefs
         every { prefs.getBoolean("show_album_name", true) } returns true
+        every { prefs.getBoolean("show_source_app", true) } returns true
         manager = LyricDisplayManager(context)
     }
 
@@ -136,5 +139,28 @@ class LyricDisplayManagerTest {
 
         // Verify Artist is just "Artist Name" (no trailing dash)
         assertEquals("Artist Name", metadata.getString(MediaMetadataCompat.METADATA_KEY_ARTIST))
+    }
+
+    @Test
+    fun `updateLyricLine omits source app when disabled`() {
+        every { prefs.getBoolean("show_source_app", true) } returns false
+        val mediaInfo = MediaInfo(
+            title = "Song Title",
+            artist = "Artist Name",
+            album = "Album Name",
+            appName = "MusicApp",
+            appPackageName = "com.music.app",
+            duration = 1000L,
+            isPlaying = true,
+            position = 0L,
+            albumArt = null,
+            appIcon = null
+        )
+
+        invokeUpdateLyricLine(mediaInfo, "Singing lyrics...")
+
+        val slot = slot<MediaMetadataCompat>()
+        verify { mediaSession.setMetadata(capture(slot)) }
+        assertNull(slot.captured.getString(MediaMetadataCompat.METADATA_KEY_ALBUM))
     }
 }

--- a/app/src/test/java/com/gululu/aamediamate/MediaStateUpdaterTest.kt
+++ b/app/src/test/java/com/gululu/aamediamate/MediaStateUpdaterTest.kt
@@ -1,0 +1,74 @@
+package com.gululu.aamediamate
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.support.v4.media.MediaMetadataCompat
+import android.support.v4.media.session.MediaSessionCompat
+import com.gululu.aamediamate.models.MediaInfo
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class MediaStateUpdaterTest {
+
+    private val context = mockk<Context>(relaxed = true)
+    private val mediaSession = mockk<MediaSessionCompat>(relaxed = true)
+    private lateinit var prefs: SharedPreferences
+    private lateinit var updater: MediaStateUpdater
+
+    @Before
+    fun setUp() {
+        prefs = mockk(relaxed = true)
+        every { context.getSharedPreferences(any(), any()) } returns prefs
+        every { context.getString(any()) } returns "Action"
+        every { prefs.getString("bridged_apps", "[]") } returns "[]"
+        every { prefs.getBoolean("show_album_name", true) } returns true
+        every { prefs.getBoolean("show_source_app", true) } returns true
+        updater = MediaStateUpdater(context)
+    }
+
+    @Test
+    fun `update includes source app by default`() {
+        updater.update(mediaSession, mediaInfo())
+
+        val metadata = capturedMetadata()
+        assertEquals("From MusicApp", metadata.getString(MediaMetadataCompat.METADATA_KEY_ALBUM))
+    }
+
+    @Test
+    fun `update omits source app when disabled`() {
+        every { prefs.getBoolean("show_source_app", true) } returns false
+
+        updater.update(mediaSession, mediaInfo())
+
+        val metadata = capturedMetadata()
+        assertNull(metadata.getString(MediaMetadataCompat.METADATA_KEY_ALBUM))
+    }
+
+    private fun capturedMetadata(): MediaMetadataCompat {
+        val metadata = slot<MediaMetadataCompat>()
+        verify { mediaSession.setMetadata(capture(metadata)) }
+        return metadata.captured
+    }
+
+    private fun mediaInfo() = MediaInfo(
+        title = "Song Title",
+        artist = "Artist Name",
+        album = "Album Name",
+        appName = "MusicApp",
+        appPackageName = "com.music.app",
+        duration = 1000L,
+        isPlaying = true,
+        position = 0L,
+        albumArt = null,
+        appIcon = null
+    )
+}

--- a/app/src/test/java/com/gululu/aamediamate/SettingsManagerDisplayTest.kt
+++ b/app/src/test/java/com/gululu/aamediamate/SettingsManagerDisplayTest.kt
@@ -1,0 +1,52 @@
+package com.gululu.aamediamate
+
+import android.content.Context
+import org.json.JSONObject
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [29])
+class SettingsManagerDisplayTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication()
+        context.getSharedPreferences("media_bridge_settings", Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+    }
+
+    @Test
+    fun `source app is shown by default`() {
+        assertTrue(SettingsManager.getShowSourceApp(context))
+    }
+
+    @Test
+    fun `source app preference is included in backup`() {
+        SettingsManager.setShowSourceApp(context, false)
+
+        val backup = SettingsManager.exportBackupSettings(context, includeSecrets = false)
+
+        assertFalse(backup.getBoolean("show_source_app"))
+    }
+
+    @Test
+    fun `source app preference is restored from backup`() {
+        SettingsManager.importBackupSettings(
+            context,
+            JSONObject().put("show_source_app", false)
+        )
+
+        assertFalse(SettingsManager.getShowSourceApp(context))
+    }
+}


### PR DESCRIPTION
Let users hide the From [app] metadata line while preserving the existing enabled default and backup behavior.